### PR TITLE
[FAS-654] Сontainerize the icon for answers components

### DIFF
--- a/src/components/AnswerWithIcon/AnswerWithIcon.tsx
+++ b/src/components/AnswerWithIcon/AnswerWithIcon.tsx
@@ -118,9 +118,7 @@ const AnswerWithIconBase: React.FC<IAnswerWithIconProps & IOptionProps> = ({
   >
     <S.Root {...props}>
       {iconSrc && (
-        <S.Icon
-          src={iconSrc}
-          alt=""
+        <div
           style={{
             width: iconWidth,
             height: iconHeight,
@@ -128,7 +126,9 @@ const AnswerWithIconBase: React.FC<IAnswerWithIconProps & IOptionProps> = ({
             minHeight: iconMinHeight,
             minWidth: iconMinWidth,
           }}
-        />
+        >
+          <S.Icon src={iconSrc} alt="" />
+        </div>
       )}
       <S.Content spacingBetweenIconAndContent={spacingBetweenIconAndContent}>
         <div>{children}</div>

--- a/src/components/AnswerWithIconAndCheckbox/AnswerWithIconAndCheckbox.tsx
+++ b/src/components/AnswerWithIconAndCheckbox/AnswerWithIconAndCheckbox.tsx
@@ -202,9 +202,7 @@ const AnswerWithIconAndCheckboxBase: React.FC<
         >
           <div>{children}</div>
         </S.Content>
-        <S.Icon
-          src={imageSrc}
-          alt=""
+        <div
           style={{
             width: imageWidth,
             minWidth: imageWidth,
@@ -212,7 +210,9 @@ const AnswerWithIconAndCheckboxBase: React.FC<
             minHeight: imageHeight,
             alignSelf: imageAlignSelf,
           }}
-        />
+        >
+          <S.Icon src={imageSrc} alt="" />
+        </div>
       </S.Root>
     </Option>
   )


### PR DESCRIPTION
https://gismart.atlassian.net/browse/FAS-654

Adding a container for the icon helps prevent page content from shifting when the image is loading slowly