### PR TITLE
ci: use self-hosted runners instead of ubuntu-latest

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -9,7 +9,7 @@ on:
           - build
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, docker]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -24,7 +24,7 @@ jobs:
         name: app-build
         path: ./dist
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, docker]
     needs: [build]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Routes `ubuntu-latest` jobs to the default self-hosted runner group (`[self-hosted, docker]`). Part of the GitHub Actions cost / self-hosted migration.